### PR TITLE
support optional img alt attr

### DIFF
--- a/make_doc
+++ b/make_doc
@@ -10,7 +10,7 @@ main([]) ->
     code:add_patha("ebin"),
     R = edoc:application(edown, ".",
 			 [{doclet, edown_doclet},
-			  {src_path, ["src"]},
+			  {source_path, ["src"]},
 			  {app_default,"http://www.erlang.org/doc/man"},
 			  {stylesheet, ""},  % don't copy stylesheet.css
 			  {image, ""},       % don't copy erlang.png

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 %% This is a reasonable set of options to use for edown, but edown
 %% doesn't actually use rebar to make its own docs.
 %% {edoc_opts, [{doclet, edown_doclet},
-%%              {src_path, ["src", "test"]},
+%%              {source_path, ["src", "test"]},
 %%              {stylesheet, ""},
 %%              {image, ""},
 %%  	        {app_default,"http://www.erlang.org/doc/man"}]}.

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -1058,11 +1058,10 @@ overview(E=#xmlElement{name = overview, content = Es}, Options) ->
     Opts = init_opts(E, Options),
     Title = [get_text(title, Es)],
     Desc = get_content(description, Es),
-    ShortDesc = get_content(briefDescription, Desc),
+%    ShortDesc = get_content(briefDescription, Desc),
     FullDesc = get_content(fullDescription, Desc),
-    Body = ([]
-	    %% ++ [{h1, [Title]}]
-	    ++ ShortDesc
+    Body = ([{h1, [Title]}]
+%	    ++ ShortDesc
 	    ++ copyright(Es)
 	    ++ version(Es)
 	    ++ since(Es)


### PR DESCRIPTION
I have just started using edown.  I faced a problem when using edown for images not having an alt attribute.

Please consider if this fix is appropriate or not.

This fix was used for the following repository (git@github.com:norton/ubf.git).
