### PR TITLE
Remove briefDescription from and add title to README.md

### DIFF
--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -1058,11 +1058,10 @@ overview(E=#xmlElement{name = overview, content = Es}, Options) ->
     Opts = init_opts(E, Options),
     Title = [get_text(title, Es)],
     Desc = get_content(description, Es),
-    ShortDesc = get_content(briefDescription, Desc),
+%    ShortDesc = get_content(briefDescription, Desc),
     FullDesc = get_content(fullDescription, Desc),
-    Body = ([]
-	    %% ++ [{h1, [Title]}]
-	    ++ ShortDesc
+    Body = ([{h1, [Title]}]
+%	    ++ ShortDesc
 	    ++ copyright(Es)
 	    ++ version(Es)
 	    ++ since(Es)


### PR DESCRIPTION
Remove briefDescription from README.md since there is no such tag
defined in the EDoc User Manual for overview.edoc.  Add title
to README.md since it is missing.  These changes are consistent
with EDoc's default layout for HTML.
