### PR TITLE
fixed imprecise match rule, and now supports cloned repositories

### DIFF
--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,9 +229,8 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		[$*,Branch]					-> Branch;
 		[$*,"(no","branch)",Branch]	-> Branch;
-		_Other						-> What = io_lib:format("~p~n", [Git]),
-									   io:format("~p~n", [Git]),
-									   erlang:error({cannot_get_git_branch, What})
+		Other						-> io:format("~p~n", [Other]), 
+									   erlang:error({cannot_get_git_branch, Other})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,8 +229,7 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		["*", Branch]					-> Branch;
 		["*", "(no", "branch)", Branch]	-> Branch;
-		Other							-> io:format("~p~n", [Other]), 
-										   erlang:error({cannot_get_git_branch, Other})
+		Other							-> erlang:error({cannot_get_git_branch, Other})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,7 +229,7 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		[$*,Branch]					-> Branch;
 		[$*,"(no","branch)",Branch]	-> Branch;
-		Other						-> erlang:error({cannot_get_git_branch, Other})
+		Other						-> erlang:error({cannot_get_git_branch, Git})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,7 +229,8 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		[$*,Branch]					-> Branch;
 		[$*,"(no","branch)",Branch]	-> Branch;
-		_Other						-> erlang:error({cannot_get_git_branch, lists:flatten(Git)})
+		_Other						-> What = io_lib:format("~s~n", Git),
+									   erlang:error({cannot_get_git_branch, What})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,7 +229,8 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		[$*,Branch]					-> Branch;
 		[$*,"(no","branch)",Branch]	-> Branch;
-		_Other						-> What = io_lib:format("~s~n", Git),
+		_Other						-> What = io_lib:format("~s~n", [Git]),
+									   io:format("~s~n", [Git]),
 									   erlang:error({cannot_get_git_branch, What})
 	end.
 

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,8 +229,7 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		["*", Branch]					-> Branch;
 		["*", "(no", "branch)", Branch]	-> Branch;
-		Other							-> io:format("~p~n", [Git]),
-											erlang:error({cannot_get_git_branch, Other})
+		Other							-> erlang:error({cannot_get_git_branch, Other})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,7 +229,7 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		[$*,Branch]					-> Branch;
 		[$*,"(no","branch)",Branch]	-> Branch;
-		Other						-> erlang:error({cannot_get_git_branch, Git})
+		_Other						-> erlang:error({cannot_get_git_branch, lists:flatten(Git)})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -227,8 +227,9 @@ do_redirect(Href, Prefix) ->
 get_git_branch() ->
 	Git = os:cmd("git branch"),
 	case string:tokens(Git, " \n") of
-		[_,Branch|[]]	-> Branch;
-		Other			-> erlang:error({cannot_get_git_branch, Other})
+		[$*,Branch]					-> Branch;
+		[$*,"(no","branch)",Branch]	-> Branch;
+		Other						-> erlang:error({cannot_get_git_branch, Other})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -227,10 +227,10 @@ do_redirect(Href, Prefix) ->
 get_git_branch() ->
 	Git = os:cmd("git branch"),
 	case string:tokens(Git, " \n") of
-		[$*,Branch]					-> Branch;
-		[$*,"(no","branch)",Branch]	-> Branch;
-		Other						-> io:format("~p~n", [Other]), 
-									   erlang:error({cannot_get_git_branch, Other})
+		["*", Branch]					-> Branch;
+		["*", "(no", "branch)", Branch]	-> Branch;
+		Other							-> io:format("~p~n", [Other]), 
+										   erlang:error({cannot_get_git_branch, Other})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,8 +229,8 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		[$*,Branch]					-> Branch;
 		[$*,"(no","branch)",Branch]	-> Branch;
-		_Other						-> What = io_lib:format("~s~n", [Git]),
-									   io:format("~s~n", [Git]),
+		_Other						-> What = io_lib:format("~p~n", [Git]),
+									   io:format("~p~n", [Git]),
 									   erlang:error({cannot_get_git_branch, What})
 	end.
 

--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -229,7 +229,8 @@ get_git_branch() ->
 	case string:tokens(Git, " \n") of
 		["*", Branch]					-> Branch;
 		["*", "(no", "branch)", Branch]	-> Branch;
-		Other							-> erlang:error({cannot_get_git_branch, Other})
+		Other							-> io:format("~p~n", [Git]),
+											erlang:error({cannot_get_git_branch, Other})
 	end.
 
 %% Tried to display logo in a table on top of page, but not working.


### PR DESCRIPTION
Last fix eliminated match on "*", which is restored here for the sake of error checking.

Additionally, when running edown through rebar, get_git_branch would throw errors on dependency repositories.  This fixes that issue, reading the slightly different output of "git branch" occurring with clones.
