### PR TITLE
added BR after Todo header

### DIFF
--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -828,7 +828,8 @@ todos(Es) ->
 	Es1 ->
 	    Todos = [{li, [{font, [{color,red}], C}]}
 		     || #xmlElement{content = C} <- Es1],
-	    [{p, [{b, [{font, [{color,red}], ["To do"]}]},{br},
+	    [{p, [{b, [{font, [{color,red}], ["To do"]}]},
+		  br,
 		  {ul, Todos}]}]
     end.
 

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -828,7 +828,7 @@ todos(Es) ->
 	Es1 ->
 	    Todos = [{li, [{font, [{color,red}], C}]}
 		     || #xmlElement{content = C} <- Es1],
-	    [{p, [{b, [{font, [{color,red}], ["To do"]}]},[br],
+	    [{p, [{b, [{font, [{color,red}], ["To do"]}]},{br},
 		  {ul, Todos}]}]
     end.
 

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -828,7 +828,7 @@ todos(Es) ->
 	Es1 ->
 	    Todos = [{li, [{font, [{color,red}], C}]}
 		     || #xmlElement{content = C} <- Es1],
-	    [{p, [{b, [{font, [{color,red}], ["To do"]}]},
+	    [{p, [{b, [{font, [{color,red}], ["To do"]}]},[br],
 		  {ul, Todos}]}]
     end.
 


### PR DESCRIPTION
First item in todo list (when {todo, true} edoc option used) was being displayed on same line as Todo header (and thus without a bullet).

Fixed. :)
