### PR TITLE
Strip excess spaces at end of text lines

### DIFF
--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -178,7 +178,10 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
 	    end,
     Desc = get_content(description, Es),
     FullDesc = get_content(fullDescription, Desc),
-    {ShortDesc, RestDesc} = get_first_sentence(FullDesc),
+
+	throw(FullDesc),
+
+	{ShortDesc, RestDesc} = get_first_sentence(FullDesc),
     Functions = [{function_name(Ex), Ex} || Ex <- get_content(functions, Es)],
     Types = [{type_name(Ex), Ex} || Ex <- get_content(typedecls, Es)],
     SortedFs = lists:sort(Functions),

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -178,9 +178,6 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
 	    end,
     Desc = get_content(description, Es),
     FullDesc = get_content(fullDescription, Desc),
-
-	if FullDesc == [] -> true; true -> throw(FullDesc) end,
-
 	{ShortDesc, RestDesc} = get_first_sentence(FullDesc),
     Functions = [{function_name(Ex), Ex} || Ex <- get_content(functions, Es)],
     Types = [{type_name(Ex), Ex} || Ex <- get_content(typedecls, Es)],

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -179,7 +179,7 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
     Desc = get_content(description, Es),
     FullDesc = get_content(fullDescription, Desc),
 
-	throw(FullDesc),
+	if FullDesc == [] -> true; true -> throw(FullDesc) end,
 
 	{ShortDesc, RestDesc} = get_first_sentence(FullDesc),
     Functions = [{function_name(Ex), Ex} || Ex <- get_content(functions, Es)],

--- a/src/edown_layout.erl
+++ b/src/edown_layout.erl
@@ -178,7 +178,7 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
 	    end,
     Desc = get_content(description, Es),
     FullDesc = get_content(fullDescription, Desc),
-	{ShortDesc, RestDesc} = get_first_sentence(FullDesc),
+    {ShortDesc, RestDesc} = get_first_sentence(FullDesc),
     Functions = [{function_name(Ex), Ex} || Ex <- get_content(functions, Es)],
     Types = [{type_name(Ex), Ex} || Ex <- get_content(typedecls, Es)],
     SortedFs = lists:sort(Functions),

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -16,7 +16,9 @@
 %% @author Ulf Wiger <ulf.wiger@erlang-solutions.com>
 %% @copyright 2010 Erlang Solutions Ltd 
 %% @end
-%% =====================================================================
+%% =============================================================================
+%% Modified 2012 by Beads Land-Trujillo:  '#text#'/1, brstrip/1
+%% =============================================================================
 
 %% Description  : Callback module for exporting XML to Markdown.
 

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -50,7 +50,7 @@ strip(Str) -> lstrip(rstrip(Str)).
 lstrip(Str) -> re:replace(Str,"^\\s","",[]).
 rstrip(Str) -> re:replace(Str, "\\s\$", []).
 
-brstrip(Str) -> re:replace(Str, "\\s\\s\$", "\\s", [global, multiline]).
+brstrip(Str) -> re:replace(Str, "\\s+\\s\$", " ", [global, multiline]).
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -41,7 +41,7 @@
 %% The '#text#' function is called for every text segment.
 
 '#text#'(Text) ->
-    to_string(Text).
+    rstrip(to_string(Text)).
 
 to_string(S) ->
     binary_to_list(iolist_to_binary([S])).

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -41,7 +41,7 @@
 %% The '#text#' function is called for every text segment.
 
 '#text#'(Text) ->
-    rstrip(to_string(Text)).
+    to_string(Text).
 
 to_string(S) ->
     binary_to_list(iolist_to_binary([S])).

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -41,7 +41,7 @@
 %% The '#text#' function is called for every text segment.
 
 '#text#'(Text) ->
-    to_string(Text).
+    brstrip(to_string(Text)).
 
 to_string(S) ->
     binary_to_list(iolist_to_binary([S])).
@@ -50,6 +50,7 @@ strip(Str) -> lstrip(rstrip(Str)).
 lstrip(Str) -> re:replace(Str,"^\\s","",[]).
 rstrip(Str) -> re:replace(Str, "\\s\$", []).
 
+brstrip(Str) -> re:replace(Str, "\\s\\s\$", "\\s", [global, multiline]).
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -50,6 +50,7 @@ strip(Str) -> lstrip(rstrip(Str)).
 lstrip(Str) -> re:replace(Str,"^\\s","",[]).
 rstrip(Str) -> re:replace(Str, "\\s\$", []).
 
+% Strip double spaces at end of line -- markdown reads as hard return.
 brstrip(Str) -> re:replace(Str, "\\s+\\s\$", " ", [global, multiline]).
 
 %% The '#root#' tag is called when the entire structure has been


### PR DESCRIPTION
Spaces are added to the ends of lines somewhere along the line in edoc/xmerl processing.

However, trailing spaces may already be present on some lines.  In these cases, markdown will see a line terminated with a double space and render as an (unintended) hard return.

Added function to reduce multi-space terminations to a single space, resolving issue.
