### PR TITLE
Add {registered, []} tuple to edown.app.src 

### DIFF
--- a/src/edown.app.src
+++ b/src/edown.app.src
@@ -20,5 +20,6 @@
   {vsn, git},
   {description, "Markdown extension for EDoc"},
   {applications, [kernel, stdlib, edoc]},
+  {registered, []},
   {env, []}
  ]}.


### PR DESCRIPTION
Missing 'registered' tuple in the app file causes `rebar generate-upgrade` to fail,
when this app is included in a release.

eg:

<pre>
==> rel-formation (generate-upgrade)
ERROR: Systools [systools:make_relup/4] aborted with: [{error_reading,
                                                        {edown,
                                                         {{missing_param,
                                                           registered},
                                                          {application,edown,
                                                           [{vsn,
                                                             "0.3.0-40-ge32e40a"},
                                                            {description,
                                                             "Markdown extension for EDoc"},
                                                            {applications,
                                                             [kernel,stdlib,
                                                              edoc]},
                                                            {env,[]},
                                                            {modules,
                                                             [edown_doclet,
                                                              edown_layout,
                                                              edown_lib,
                                                              edown_make,
                                                              edown_xmerl]}]}}}}]
ERROR: 'generate-upgrade' failed while processing /..redacted../rel: rebar_abort
</pre>
