### PR TITLE
Use git rev-parse to obtain current branch name

### DIFF
--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -225,11 +225,11 @@ do_redirect(Href, Prefix) ->
     end.
 
 get_git_branch() ->
-    case os:cmd("git describe --always --all") of
+    case os:cmd("git rev-parse --abbrev-ref HEAD") of
 	"fatal:" ++ _ -> "master";  % sensible default
 	Git ->
-	    case string:tokens(Git, " \n/") of
-		[_, Branch]	-> Branch;
+	    case string:tokens(Git, " \n") of
+		[Branch]	-> Branch;
 		Other		-> erlang:error({cannot_get_git_branch, Other})
 	    end
     end.


### PR DESCRIPTION
Obtaining the current branch name using describe is roundabout and the
tokenization that includes '/' is broken for any branch with '/' in
its name (a common git practice). Using `git rev-parse --abbrev-ref
HEAD` seems to provide the current branch name in an easy to parse
fashion.
