### PR TITLE
Tweaks to generated markdown

### DIFF
--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -32,7 +32,7 @@
 	 '#element#'/5,
 	 '#text#'/1]).
 
--import(xmerl_lib, [markup/3, find_attribute/2, export_text/1]).
+-import(xmerl_lib, [find_attribute/2]).
 
 -include_lib("xmerl/include/xmerl.hrl").
 

--- a/src/edown_xmerl.erl
+++ b/src/edown_xmerl.erl
@@ -189,10 +189,10 @@ md_elem(Tag, Data, Attrs, Parents, E) ->
 	dl    -> Data;
 	dt    -> html_elem(dt, Data, Attrs, Parents, E);
 	dd    -> html_elem(dd, Data, Attrs, Parents, E);
-	h1 -> ["\n\n#", no_nl(Data), "#\n"];
-	h2 -> ["\n\n##", no_nl(Data), "##\n"];
-	h3 -> ["\n\n###", no_nl(Data), "##\n"];
-	h4 -> ["\n\n####", no_nl(Data), "##\n"];
+	h1 -> ["\n\n# ", no_nl(Data), " #\n"];
+	h2 -> ["\n\n## ", no_nl(Data), " ##\n"];
+	h3 -> ["\n\n### ", no_nl(Data), " ###\n"];
+	h4 -> ["\n\n#### ", no_nl(Data), " ####\n"];
 	hr -> "---------\n";
 	head -> [];
 	_ ->


### PR DESCRIPTION
Hi Ulf,

Not sure if you will care for all or some of these patches. I've only tested them on an `overview.edoc` in one of my projects where I've started to experiment with making use of edown. That said, I think they improve the generated markdown.
- Remove unused imports from merl_lib in edown_xmerl
- Generated github-style "fenced" code blocks instead of `<pre>` tags.
- Fix "close" of markdown headers, octothorpe counts should match
- Adjust newline behavior for generated markdown. I see there is an existing issue/PR for this and am unclear if what I've done somehow breaks some edge cases. To my eye, the generated markdown is easier to read and I think will be "correct" for github use (I put that in quotes b/c markdown is markdown).
