### PR TITLE
Fixed bug where utf8 was being passed as package when writing the README...

### DIFF
--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -139,7 +139,7 @@ gen(Sources, App, Packages, Modules, FileMap, Ctxt) ->
 	 ++ lists:concat([modules_frame(Modules1) || Modules1 =/= []]),
 
     Text = xmerl:export_simple_content(Data, edown_xmerl),
-    write_file(Text, Dir, right_suffix(?INDEX_FILE, Options), '', utf8),
+    write_file(Text, Dir, right_suffix(?INDEX_FILE, Options), '', ''),
     edoc_lib:write_info_file(App, Packages, Modules1, Dir),
     copy_stylesheet(Dir, Options),
     copy_image(Dir, Options),


### PR DESCRIPTION
When calling write_file for the README.md file, 'utf8' was being passed as the package name. This resulted in the README.md being placed in a subdirectory named "utf" in the output directory. To fix this I simple replaced utf8 with a blank package name, and then rely upon write_file to automatically resolve the encoding.
