### PR TITLE
Improved encoding guessing for source files

### DIFF
--- a/src/edown_doclet.erl
+++ b/src/edown_doclet.erl
@@ -319,11 +319,11 @@ source({M, P, Name, Path}, Dir, Suffix, Env, Set, Private, Hidden,
 
 guess_encoding(File) ->
     try epp:read_encoding(File) of
-        none -> latin1;
+        none -> epp:default_encoding();
         Enc  -> Enc
     catch
         _:_ ->
-            latin1
+            epp:default_encoding()
     end.
 
 write_file(Text, Dir, F) ->


### PR DESCRIPTION
For source files, rather than hardcoding the default encoding to latin1, it is better to use epp:default_encoding().
